### PR TITLE
[#86543196] remove existing deployement files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+coverage.out

--- a/opsmanager.go
+++ b/opsmanager.go
@@ -1,14 +1,15 @@
 package cfbackup
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path"
 
-	cfhttp "github.com/pivotalservices/gtils/http"
 	"github.com/pivotalservices/gtils/command"
+	cfhttp "github.com/pivotalservices/gtils/http"
 	"github.com/pivotalservices/gtils/osutils"
 )
 
@@ -94,10 +95,20 @@ func (context *OpsManager) Restore() (err error) {
 }
 
 func (context *OpsManager) importInstallation() (err error) {
+	defer func() {
+		err = context.removeExistingDeploymentFiles()
+	}()
 
 	if err = context.importInstallationPart(OPSMGR_INSTALLATION_SETTINGS_FILENAME, OPSMGR_INSTALLATION_SETTINGS_POSTFIELD_NAME, context.SettingsUploader); err == nil {
 		err = context.importInstallationPart(OPSMGR_INSTALLATION_ASSETS_FILENAME, OPSMGR_INSTALLATION_ASSETS_POSTFIELD_NAME, context.AssetsUploader)
 	}
+	return
+}
+
+func (context *OpsManager) removeExistingDeploymentFiles() (err error) {
+	var w bytes.Buffer
+	command := "sudo rm /var/tempest/workspaces/default/deployments/bosh-deployments.yml"
+	err = context.Executer.Execute(&w, command)
 	return
 }
 

--- a/opsmanager_test.go
+++ b/opsmanager_test.go
@@ -22,7 +22,7 @@ var _ = Describe("OpsManager object", func() {
 	)
 	Describe("Restore method", func() {
 
-		Context("calling restore successfully", func() {
+		Context("calling restore with failed removal of deployment files", func() {
 
 			BeforeEach(func() {
 				tmpDir, _ = ioutil.TempDir("/tmp", "test")
@@ -40,6 +40,39 @@ var _ = Describe("OpsManager object", func() {
 					},
 					RestRunner:          RestAdapter(restFailure),
 					Executer:            &failExecuter{},
+					DeploymentDir:       "fixtures/encryptionkey",
+					OpsmanagerBackupDir: "opsmanager",
+				}
+				f, _ := osutils.SafeCreate(opsManager.TargetDir, opsManager.OpsmanagerBackupDir, OPSMGR_INSTALLATION_SETTINGS_FILENAME)
+				f.Close()
+				f, _ = osutils.SafeCreate(opsManager.TargetDir, opsManager.OpsmanagerBackupDir, OPSMGR_INSTALLATION_ASSETS_FILENAME)
+				f.Close()
+			})
+
+			It("Should yield error", func() {
+				err := opsManager.Restore()
+				Ω(err).ShouldNot(BeNil())
+			})
+		})
+
+		Context("calling restore successfully", func() {
+
+			BeforeEach(func() {
+				tmpDir, _ = ioutil.TempDir("/tmp", "test")
+				backupDir = path.Join(tmpDir, "backup", "opsmanager")
+				gw := &successGateway{}
+
+				opsManager = &OpsManager{
+					SettingsUploader: gw,
+					AssetsUploader:   gw,
+					Hostname:         "localhost",
+					Username:         "user",
+					Password:         "password",
+					BackupContext: BackupContext{
+						TargetDir: path.Join(tmpDir, "backup"),
+					},
+					RestRunner:          RestAdapter(restFailure),
+					Executer:            &successExecuter{},
 					DeploymentDir:       "fixtures/encryptionkey",
 					OpsmanagerBackupDir: "opsmanager",
 				}


### PR DESCRIPTION
as part of the restore process we need to
remove any existing deployment files, before
we run the install...

this sets the last step of the import to remove the deployment
files. this way we can be relatively certain that
the files are cleared before the install
runs