### PR TITLE
[#91529554] - Add index for availability zones

### DIFF
--- a/fixtures/deployment_vms.json
+++ b/fixtures/deployment_vms.json
@@ -84,6 +84,24 @@
     "index": 0
   },
   {
+    "agent_id": "d4131496-4cdf-4309-907b-e2ce327be029",
+    "cid": "vm-8dfe3b38-6e31-4d9a-aeef-74cbf2143bd8",
+    "job": "cloud_controller-partition-7bc61fd2fa9d654696df",
+    "index": 1
+  },
+  {
+    "agent_id": "d4131496-4cdf-4309-907b-e2ce327be029",
+    "cid": "vm-8dfe3b38-6e31-4d9a-aeef-74cbf2143bd8",
+    "job": "cloud_controller-partition-6bc61fd2fa9d654696d",
+    "index": 0
+  },
+  {
+    "agent_id": "d4131496-4cdf-4309-907b-e2ce327be029",
+    "cid": "vm-8dfe3b38-6e31-4d9a-aeef-74cbf2143bd8",
+    "job": "cloud_controller-partition-6bc61fd2fa9d654696d",
+    "index": 1
+  },
+  {
     "agent_id": "7c0c1044-16d7-4009-93a2-b05eaa9ee0f2",
     "cid": "vm-457d505c-f5fd-4061-976d-14cd5903c823",
     "job": "cloud_controller_worker-partition-7bc61fd2fa9d654696df",

--- a/get_cc_vms.go
+++ b/get_cc_vms.go
@@ -10,31 +10,36 @@ import (
 
 type (
 	VMObject struct {
-		Job string
+		Job   string
+		Index int
 	}
 
 	CloudControllerDeploymentParser struct {
-		vms []string
+		vms []CCJob
 	}
 )
 
-func GetCCVMs(jsonObj []VMObject) ([]string, error) {
+func GetCCVMs(jsonObj []VMObject) ([]CCJob, error) {
 	parser := &CloudControllerDeploymentParser{}
 	return parser.Parse(jsonObj)
 }
 
-func (s *CloudControllerDeploymentParser) Parse(jsonObj []VMObject) ([]string, error) {
+func (s *CloudControllerDeploymentParser) Parse(jsonObj []VMObject) ([]CCJob, error) {
 	err := s.setupAndRun(jsonObj)
 	return s.vms, err
 }
 
 func (s *CloudControllerDeploymentParser) setupAndRun(jsonObj []VMObject) (err error) {
 
-	var ccjobs = make([]string, 0)
+	var ccjobs = make([]CCJob, 0)
 
 	for _, vmObject := range jsonObj {
 		if strings.Contains(vmObject.Job, "cloud_controller-partition") {
-			ccjobs = append(ccjobs, vmObject.Job)
+			ccJob := CCJob{
+				Job:   vmObject.Job,
+				Index: vmObject.Index,
+			}
+			ccjobs = append(ccjobs, ccJob)
 		}
 	}
 

--- a/get_cc_vms_test.go
+++ b/get_cc_vms_test.go
@@ -23,10 +23,17 @@ var _ = Describe("get_cc_vms", func() {
 			})
 
 			It("Should return nil error, correct cc jobs", func() {
-				vms, err := GetCCVMs(jsonObj)
+				_, err := GetCCVMs(jsonObj)
 				Ω(err).Should(BeNil())
-				Ω(vms).Should(HaveLen(1))
-				Ω(vms[0]).Should(Equal("cloud_controller-partition-7bc61fd2fa9d654696df"))
+			})
+
+			It("Should have 4 cc correct jobs", func() {
+				vms, _ := GetCCVMs(jsonObj)
+				Ω(vms).Should(HaveLen(4))
+				Ω(vms[0].Index).Should(Equal(0))
+				Ω(vms[1].Index).Should(Equal(1))
+				Ω(vms[2].Index).Should(Equal(0))
+				Ω(vms[3].Index).Should(Equal(1))
 			})
 
 			It("Should not panic on complete real world dataset", func() {
@@ -70,11 +77,14 @@ var _ = Describe("get_cc_vms", func() {
 			AfterEach(func() {
 			})
 
-			It("Should return nil error, correct cc job", func() {
-				vms, err := parser.Parse(jsonObj)
+			It("Should return nil error", func() {
+				_, err := parser.Parse(jsonObj)
 				Ω(err).Should(BeNil())
-				Ω(vms).Should(HaveLen(1))
-				Ω(vms[0]).Should(Equal("cloud_controller-partition-7bc61fd2fa9d654696df"))
+			})
+
+			It("Should return 4 jobs", func() {
+				vms, _ := parser.Parse(jsonObj)
+				Ω(vms).Should(HaveLen(4))
 			})
 
 			It("Should not panic on complete real world dataset", func() {

--- a/toggle_cc_job_test.go
+++ b/toggle_cc_job_test.go
@@ -2,9 +2,11 @@ package cfbackup_test
 
 import (
 	"errors"
-	. "github.com/pivotalservices/cfbackup"
 	"io"
+	"strings"
 	"time"
+
+	. "github.com/pivotalservices/cfbackup"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -12,15 +14,19 @@ import (
 )
 
 var (
-	getManifest             bool = true
-	getTaskStatus           bool = true
-	changeJobState          bool = true
-	manifest                io.Reader
-	ip                      string              = "10.10.10.10"
-	username                string              = "test"
-	password                string              = "test"
-	deploymentName          string              = "deployment"
-	ccjobs                  CloudControllerJobs = CloudControllerJobs{"job1", "job2", "job3"}
+	getManifest    bool                = true
+	getTaskStatus  bool                = true
+	changeJobState bool                = true
+	manifest       io.Reader           = strings.NewReader("manifest")
+	ip             string              = "10.10.10.10"
+	username       string              = "test"
+	password       string              = "test"
+	deploymentName string              = "deployment"
+	ccjobs         CloudControllerJobs = CloudControllerJobs{
+		CCJob{Job: "job1", Index: 0},
+		CCJob{Job: "job2", Index: 1},
+		CCJob{Job: "job3", Index: 0},
+	}
 	task                    bosh.Task
 	doneTask                bosh.Task = bosh.Task{}
 	changeJobStateCount     int       = 0
@@ -61,7 +67,7 @@ var _ = Describe("ToggleCcJob", func() {
 	}
 	TaskPingFreq = time.Millisecond
 	var (
-		cloudController *CloudController = NewCloudController(ip, username, password, deploymentName, ccjobs)
+		cloudController *CloudController = NewCloudController(ip, username, password, deploymentName, "manifest", ccjobs)
 	)
 	Describe("Toggle All jobs", func() {
 		Context("Change Job State failed", func() {


### PR DESCRIPTION
This fixed two issues:

For manifest retrieving, converted from io.Reader to strings, so it can be used by multiple job state change. (io.Reader drained by first job and can not be used by the following ones)

For AZ's enabled cloudcontroller job state change. Convert the parsed data structure from []string to a struct with both job name and index. So we are not losing the correct index from API.